### PR TITLE
Updates the README documentation of the WatchKit usage for `passMessageObject`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ let wormhole = MMWormhole(applicationGroupIdentifier: "group.com.yourcompany", o
 ```swift
 // assumes wormhole is initialised (above)
 
-wormhole.passMessageObject("titleString", identifier: "from_watch_queue")
+wormhole.passMessageObject("titleString" as NSCoding?, identifier: "from_watch_queue");
 ```
 
 #### Listen for messages (WatchKit extension, swift)


### PR DESCRIPTION
Since `wormhole.passMessageObject` requires a `NSCoding` class to be passed as the first argument.  It needs to be cast.

References: https://github.com/leecrossley/cordova-plugin-apple-watch/issues/60